### PR TITLE
fixing broken link for wPOPKT Safe

### DIFF
--- a/learn-about-pokt/the-economics.md
+++ b/learn-about-pokt/the-economics.md
@@ -2,15 +2,13 @@
 
 POKT is the lifeblood of the POKT Network ecosystem. It coordinates all actors within the ecosystem and drives the core utility of the network.
 
-
-
 <figure><img src="../.gitbook/assets/spaces_HVZ3BQcmJhVmXh7fy6xP_uploads_qoRt8gKnYOtnXs06l6W4_The Growth Flywheel (1).webp" alt=""><figcaption></figcaption></figure>
 
 ## The role of POKT within the protocol
 
-* Node runners currently need to stake at least 15,000 POKT to operate a POKT node. We expect this requirement to change once Shannon is deployed to mainnet later this year.
-* Validators must stake enough POKT to become one of the 1,000 validators, a protocol-defined cap. The current “validator threshold” is 75,100 POKT [as per POKTscan](https://poktscan.com/). (Validators might be replaced by Sequencers in the Shannon protocol upgrade).
-* Every gateway routing traffic to POKT Network’s decentralized network of nodes must pay a “Gateway Operator Fee” of $0.00000085 per relay, as per the [protocol burn proposal](https://forum.pokt.network/t/pip-29-burn-gateway-burn/4401) passed on 16 May 2023. Paid in POKT, these fees are burned. Approximately 6.5m POKT were burned over the 12 months since burning began in May 2023, an average of 540,000 per month. (For live metrics, refer to [https://pokt.money](https://pokt.money/).)
+- Node runners currently need to stake at least 15,000 POKT to operate a POKT node. We expect this requirement to change once Shannon is deployed to mainnet later this year.
+- Validators must stake enough POKT to become one of the 1,000 validators, a protocol-defined cap. The current “validator threshold” is 75,100 POKT [as per POKTscan](https://poktscan.com/). (Validators might be replaced by Sequencers in the Shannon protocol upgrade).
+- Every gateway routing traffic to POKT Network’s decentralized network of nodes must pay a “Gateway Operator Fee” of $0.00000085 per relay, as per the [protocol burn proposal](https://forum.pokt.network/t/pip-29-burn-gateway-burn/4401) passed on 16 May 2023. Paid in POKT, these fees are burned. Approximately 6.5m POKT were burned over the 12 months since burning began in May 2023, an average of 540,000 per month. (For live metrics, refer to [https://pokt.money](https://pokt.money/).)
 
 {% hint style="info" %}
 There is a flywheel effect in place for POKT's economics as more gateways drive more relays to the network, requiring gateways to buy more POKT, which is then burned. More relays incentivize more node runners to join the network to earn rewards, and with more node runners with better QoS, more gateways, in turn, are incentivized to bring more of their business to POKT Network, which keeps the flywheel turning.
@@ -30,9 +28,9 @@ POKT's latest supply schedule is dictated by [ARR (Accelerating the Road to Reve
 
 All POKT minted in each block is distributed as follows:
 
-* 85% to the node runners for serving the relays
-* 5% to the validators for securing the network
-* 10% to the DAO treasury
+- 85% to the node runners for serving the relays
+- 5% to the validators for securing the network
+- 10% to the DAO treasury
 
 ## Total and Circulating supply of POKT
 
@@ -46,12 +44,12 @@ Other data providers, such as POKTscan, calculate the circulating supply of POKT
 
 For community reference, all of the DAO- and PNF-controlled wallets are listed below:
 
-* the [DAO Treasury](https://poktscan.com/explore?tab=governance)
-* the [DAO ERA Budget wallet](https://poktscan.com/account/4e67bdb7d099c8a754b22c852a9fe140b7d47849) (containing all POKT to fund upcoming [ERA expenses](https://forum.pokt.network/t/pep-60-enabling-responsible-allocation-of-budget-era-budget/4443))&#x20;
-* the [DAO's wPOKT SAFE on Ethereum](eth:0x2f16615234827eE4dF14d02d40C24E6a258dD360) (used to launch the wPOKT pool)
-* the [DAO's Gnosis SAFE on Ethereum](https://app.safe.global/transactions/history?safe=eth:0x7bAAf6cAEE858929a68a98a70a428b8BEB4d4093) (used to pay DAO contributors)
-* the [main PNF POKT Treasury wallet](https://poktscan.com/node/186afc505903e7c7aa97d5f7f1c555111e2ae2ce)
-* [PNF's Gnosis SAFE on Ethereum](https://app.safe.global/transactions/history?safe=eth:0x963810F5D0FB29286156C833FcF30ab760D5Bad8) (used to pay contractors and agencies).
+- the [DAO Treasury](https://poktscan.com/explore?tab=governance)
+- the [DAO ERA Budget wallet](https://poktscan.com/account/4e67bdb7d099c8a754b22c852a9fe140b7d47849) (containing all POKT to fund upcoming [ERA expenses](https://forum.pokt.network/t/pep-60-enabling-responsible-allocation-of-budget-era-budget/4443))&#x20;
+- the [DAO's wPOKT SAFE on Ethereum](https://app.safe.global/transactions/history?safe=eth:0x2f16615234827eE4dF14d02d40C24E6a258dD360) (used to launch the wPOKT pool)
+- the [DAO's Gnosis SAFE on Ethereum](https://app.safe.global/transactions/history?safe=eth:0x7bAAf6cAEE858929a68a98a70a428b8BEB4d4093) (used to pay DAO contributors)
+- the [main PNF POKT Treasury wallet](https://poktscan.com/node/186afc505903e7c7aa97d5f7f1c555111e2ae2ce)
+- [PNF's Gnosis SAFE on Ethereum](https://app.safe.global/transactions/history?safe=eth:0x963810F5D0FB29286156C833FcF30ab760D5Bad8) (used to pay contractors and agencies).
 
 ## Supply projections for POKT
 
@@ -62,10 +60,8 @@ The main drivers of the supply of POKT are:
 
 The graphs below illustrate the potential supply growth for POKT over time and how that impacts the total supply of POKT. Please note that these projections are based on a USD/POKT price of $0.15 and 60b relays by day in 2028.
 
-
-
 <figure><img src="../.gitbook/assets/spaces_HVZ3BQcmJhVmXh7fy6xP_uploads_git-blob-132a5f527c0f9fe00e572549efa5124bfc1ee3f4_image (1) (1).webp" alt=""><figcaption><p>Total supply for POKT over time based on such assumptions</p></figcaption></figure>
 
 <figure><img src="https://files.gitbook.com/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F9frYjAjtKqZHrIgdCbj2%2Fuploads%2FVkvKrQjmErUCRX7VHcwS%2Fspaces_HVZ3BQcmJhVmXh7fy6xP_uploads_git-blob-a9cd805eb5ed6137e2cc873b760a9083736deda9_image%20(2).webp?alt=media&#x26;token=841fd9d7-20eb-46af-a8ad-9b3335f03bfa" alt=""><figcaption><p>Supply growth for POKT based on an indicative number of relays and price per POKT</p></figcaption></figure>
 
-Others may be more optimistic or conservative in their approach to the variables underlying these graphs. We invite the community to fork the numbers in [this spreadsheet](https://docs.google.com/spreadsheets/d/1y4ZpBBR\_ytbp5EGqYc6Hsg5vw6CSeXn\_KEuKOMRHIbM/edit?usp=sharing) to create their own projections based on their assumptions for the price of POKT, the number of POKT needed to reward node runners, the number of relays, and the Gateway Operator Fee.
+Others may be more optimistic or conservative in their approach to the variables underlying these graphs. We invite the community to fork the numbers in [this spreadsheet](https://docs.google.com/spreadsheets/d/1y4ZpBBR_ytbp5EGqYc6Hsg5vw6CSeXn_KEuKOMRHIbM/edit?usp=sharing) to create their own projections based on their assumptions for the price of POKT, the number of POKT needed to reward node runners, the number of relays, and the Gateway Operator Fee.


### PR DESCRIPTION
replaces broken link for wPOKT safe in `/learn-about-pokt/the-economics#total-and-circulating-supply-of-pokt`